### PR TITLE
Refactor user registration and improve admin role management

### DIFF
--- a/backend/backend.did
+++ b/backend/backend.did
@@ -89,6 +89,7 @@ type Result_6 = variant { Ok : UserProfile; Err : text };
 type TransformArgs = record { context : blob; response : HttpRequestResult };
 type UserProfile = record {
   last_login : nat64;
+  assigned_institution_name : text;
   name : text;
   role : UserRole;
   created_at : nat64;

--- a/backend/backend.did
+++ b/backend/backend.did
@@ -102,6 +102,9 @@ service : () -> {
   admin_create_institution_for_user : (principal, text, text) -> (Result);
   // Admin function: Delete a user (super admin only)
   admin_delete_user : (principal) -> (Result_1);
+  // Admin function: Demote super admin to regular user (super admin only)
+  // Note: Super admins cannot demote themselves
+  admin_demote_super_admin : (principal) -> (Result_1);
   // Admin function: Get all users (admin only)
   admin_get_all_users : () -> (Result_2) query;
   // Admin function: Get cycle monitoring information (admin only)
@@ -149,8 +152,22 @@ service : () -> {
   get_user_profile : () -> (Result_5) query;
   // Check if a user owns a specific document (direct query)
   is_document_owned_by : (text, principal) -> (bool) query;
-   // Unified document query function with comprehensive filtering, sorting, and pagination
-   query_documents : (opt text, opt principal, opt text, opt text, opt nat8, opt nat16, opt nat64, opt nat64, opt nat64, opt nat64, opt text, opt text, opt bool) -> (vec Document, nat64) query;
+  // Unified document query function with comprehensive filtering, sorting, and pagination
+  query_documents : (
+      opt text,
+      opt principal,
+      opt text,
+      opt text,
+      opt nat8,
+      opt nat16,
+      opt nat64,
+      opt nat64,
+      opt nat64,
+      opt nat64,
+      opt text,
+      opt text,
+      opt bool,
+    ) -> (vec Document, nat64) query;
   // Public function for users to register themselves (called after Internet Identity login)
   // Used as well to update the last_login timestamp for existing users
   register_user : (text, text) -> (Result_6);

--- a/backend/backend.did
+++ b/backend/backend.did
@@ -153,6 +153,8 @@ service : () -> {
   get_user_profile : () -> (Result_5) query;
   // Check if a user owns a specific document (direct query)
   is_document_owned_by : (text, principal) -> (bool) query;
+  // Login existing user (updates last login timestamp)
+  login_user : () -> (Result_6);
   // Unified document query function with comprehensive filtering, sorting, and pagination
   query_documents : (
       opt text,
@@ -169,8 +171,7 @@ service : () -> {
       opt text,
       opt bool,
     ) -> (vec Document, nat64) query;
-  // Public function for users to register themselves (called after Internet Identity login)
-  // Used as well to update the last_login timestamp for existing users
+  // Register a new user (called after Internet Identity login for first-time users)
   register_user : (text, text) -> (Result_6);
   // Search documents by name (case-insensitive partial match)
   search_documents_by_name : (text) -> (vec Document) query;
@@ -181,6 +182,8 @@ service : () -> {
   transform_gemini_response : (TransformArgs) -> (HttpRequestResult) query;
   // Update institution metadata (only owner can update)
   update_institution : (text, text, text) -> (Result_1);
+  // Update user name and email (users can update their own profile, super admins can update any profile)
+  update_user_profile : (opt principal, text, text) -> (Result_6);
   // Custom upload endpoint for publishing documents to the icp blockchain
   upload_file_and_publish_document : (Document) -> (DocumentResponse);
   whoami : () -> (principal) query;

--- a/backend/src/functions/admin_queries.rs
+++ b/backend/src/functions/admin_queries.rs
@@ -27,7 +27,16 @@ pub fn admin_get_all_users() -> Result<Vec<UserProfile>, String> {
     
     let users = USER_PROFILES.with(|profiles| {
         profiles.borrow().iter()
-            .map(|(_, storable_profile)| storable_profile.0)
+            .map(|(_, storable_profile)| {
+                let mut user = storable_profile.0.clone();
+                // Populate institution name if ID exists but name is empty
+                if !user.assigned_institution_id.is_empty() && user.assigned_institution_name.is_empty() {
+                    if let Some(institution) = crate::storage::get_institution_safe(&user.assigned_institution_id) {
+                        user.assigned_institution_name = institution.name;
+                    }
+                }
+                user
+            })
             .collect()
     });
     
@@ -41,7 +50,7 @@ pub fn admin_get_users_without_institutions() -> Result<Vec<UserProfile>, String
     
     let users = USER_PROFILES.with(|profiles| {
         profiles.borrow().iter()
-            .map(|(_, storable_profile)| storable_profile.0)
+            .map(|(_, storable_profile)| storable_profile.0.clone())
             .filter(|profile| profile.assigned_institution_id.is_empty())
             .collect()
     });
@@ -99,6 +108,7 @@ pub fn admin_create_institution_for_user(
         email: current_profile.email,
         role: UserRole::InstitutionMember(institution_id.clone()),
         assigned_institution_id: institution_id.clone(),
+        assigned_institution_name: institution.name.clone(),
         created_at: current_profile.created_at,
         last_login: current_profile.last_login,
     };
@@ -130,6 +140,7 @@ pub fn admin_promote_to_super_admin(user_identity: Principal) -> Result<(), Stri
             // Update existing profile
             profile.role = UserRole::SuperAdmin;
             profile.assigned_institution_id = String::new(); // Super admins should not be assigned to institutions
+            profile.assigned_institution_name = String::new();
             USER_PROFILES.with(|profiles| {
                 profiles.borrow_mut().insert(profile_key, crate::storage::memory::StorableUserProfile(profile));
             });
@@ -143,6 +154,7 @@ pub fn admin_promote_to_super_admin(user_identity: Principal) -> Result<(), Stri
                 email: String::new(), // Will be set when user updates their profile
                 role: UserRole::SuperAdmin,
                 assigned_institution_id: String::new(),
+                assigned_institution_name: String::new(),
                 created_at: get_current_timestamp(),
                 last_login: 0,
             };
@@ -204,10 +216,8 @@ pub fn admin_link_user_to_institution(
     }
     
     // Check if institution exists
-    let institution_exists = crate::storage::get_institution_safe(&institution_id).is_some();
-    if !institution_exists {
-        return Err("Institution not found".to_string());
-    }
+    let institution = crate::storage::get_institution_safe(&institution_id)
+        .ok_or("Institution not found")?;
     
     // Get current user profile
     let current_profile = crate::storage::get_user_profile_safe(&user_identity)
@@ -230,6 +240,7 @@ pub fn admin_link_user_to_institution(
         email: current_profile.email,
         role: UserRole::InstitutionMember(institution_id.clone()),
         assigned_institution_id: institution_id.clone(),
+        assigned_institution_name: institution.name.clone(),
         created_at: current_profile.created_at,
         last_login: current_profile.last_login,
     };
@@ -271,6 +282,7 @@ pub fn admin_unlink_user_from_institution(user_identity: Principal) -> Result<()
         email: current_profile.email,
         role: UserRole::RegularUser, // Change role back to RegularUser
         assigned_institution_id: String::new(), // Clear institution assignment
+        assigned_institution_name: String::new(),
         created_at: current_profile.created_at,
         last_login: current_profile.last_login,
     };
@@ -304,6 +316,7 @@ pub fn bootstrap_first_super_admin() -> Result<(), String> {
         email: String::new(), // Will be set when user updates their profile
         role: UserRole::SuperAdmin,
         assigned_institution_id: String::new(),
+        assigned_institution_name: String::new(),
         created_at: get_current_timestamp(),
         last_login: get_current_timestamp(),
     };

--- a/backend/src/functions/user_management.rs
+++ b/backend/src/functions/user_management.rs
@@ -8,7 +8,19 @@ use crate::logging::{get_logger, get_severity_for_event_type};
 #[query]
 pub fn get_user_profile() -> Result<Option<UserProfile>, String> {
     let caller = require_authenticated_user()?;
-    Ok(crate::storage::get_user_profile_safe(&caller))
+    let profile = crate::storage::get_user_profile_safe(&caller);
+    
+    // Populate institution name if ID exists but name is empty
+    if let Some(mut user) = profile {
+        if !user.assigned_institution_id.is_empty() && user.assigned_institution_name.is_empty() {
+            if let Some(institution) = crate::storage::get_institution_safe(&user.assigned_institution_id) {
+                user.assigned_institution_name = institution.name;
+            }
+        }
+        Ok(Some(user))
+    } else {
+        Ok(None)
+    }
 }
 
 /// Public function for users to register themselves (called after Internet Identity login)
@@ -47,6 +59,7 @@ pub fn register_user(name: String, email: String) -> Result<UserProfile, String>
         email,
         role: UserRole::RegularUser,
         assigned_institution_id: String::new(), // Empty until admin assigns
+        assigned_institution_name: String::new(),
         created_at: get_current_timestamp(),
         last_login: get_current_timestamp(),
     };

--- a/backend/src/functions/user_management.rs
+++ b/backend/src/functions/user_management.rs
@@ -23,8 +23,7 @@ pub fn get_user_profile() -> Result<Option<UserProfile>, String> {
     }
 }
 
-/// Public function for users to register themselves (called after Internet Identity login)
-/// Used as well to update the last_login timestamp for existing users
+/// Register a new user (called after Internet Identity login for first-time users)
 #[update]
 pub fn register_user(name: String, email: String) -> Result<UserProfile, String> {
     let caller = require_authenticated_user()?;
@@ -34,22 +33,13 @@ pub fn register_user(name: String, email: String) -> Result<UserProfile, String>
     crate::utils::validate_email(&email)?;
     
     // Check if profile already exists
-    if let Some(existing_profile) = crate::storage::get_user_profile_safe(&caller) {
-        // If user exists but has empty name/email, update them
-        if existing_profile.name.is_empty() || existing_profile.email.is_empty() {
-            let mut updated_profile = existing_profile;
-            updated_profile.name = name;
-            updated_profile.email = email;
-            updated_profile.last_login = get_current_timestamp();
-            crate::storage::update_user_profile_safe(&caller, &updated_profile)?;
-            return Ok(updated_profile);
-        }
-        
-        // If user already has name/email, just update last_login timestamp
-        let mut updated_profile = existing_profile;
-        updated_profile.last_login = get_current_timestamp();
-        crate::storage::update_user_profile_safe(&caller, &updated_profile)?;
-        return Ok(updated_profile);
+    if crate::storage::get_user_profile_safe(&caller).is_some() {
+        return Err("User already registered. Use login_user to track login.".to_string());
+    }
+    
+    // Check for duplicate email
+    if crate::storage::email_exists(&email) {
+        return Err("Email already registered. Please use a different email address.".to_string());
     }
     
     // Create new regular user profile
@@ -58,7 +48,7 @@ pub fn register_user(name: String, email: String) -> Result<UserProfile, String>
         name,
         email,
         role: UserRole::RegularUser,
-        assigned_institution_id: String::new(), // Empty until admin assigns
+        assigned_institution_id: String::new(),
         assigned_institution_name: String::new(),
         created_at: get_current_timestamp(),
         last_login: get_current_timestamp(),
@@ -73,6 +63,69 @@ pub fn register_user(name: String, email: String) -> Result<UserProfile, String>
     logger.log(severity, "USER_REGISTRATION", &format!("New user registered: {}", caller), Some(caller.to_string()));
     
     Ok(new_profile)
+}
+
+/// Login existing user (updates last login timestamp)
+#[update]
+pub fn login_user() -> Result<UserProfile, String> {
+    let caller = require_authenticated_user()?;
+    
+    // Get existing profile
+    let mut profile = crate::storage::get_user_profile_safe(&caller)
+        .ok_or_else(|| "User not found. Please register first.".to_string())?;
+    
+    // Update last_login timestamp
+    profile.last_login = get_current_timestamp();
+    crate::storage::update_user_profile_safe(&caller, &profile)?;
+    
+    Ok(profile)
+}
+
+/// Update user name and email (users can update their own profile, super admins can update any profile)
+#[update]
+pub fn update_user_profile(user_identity: Option<Principal>, name: String, email: String) -> Result<UserProfile, String> {
+    let caller = require_authenticated_user()?;
+    
+    // If user_identity is not provided, default to caller
+    let target_user = user_identity.unwrap_or(caller);
+    
+    // Check if caller is the user being updated OR is a super admin
+    let is_super_admin = if let Some(caller_profile) = crate::storage::get_user_profile_safe(&caller) {
+        caller_profile.role == UserRole::SuperAdmin
+    } else {
+        false
+    };
+    
+    if caller != target_user && !is_super_admin {
+        return Err("Access denied. You can only update your own profile.".to_string());
+    }
+    
+    // Validate inputs
+    crate::utils::validate_string_length(&name, 2, 100, "Name")?;
+    crate::utils::validate_email(&email)?;
+    
+    // Check for duplicate email (excluding the user being updated)
+    if crate::storage::email_exists_excluding_user(&email, &target_user) {
+        return Err("Email already registered. Please use a different email address.".to_string());
+    }
+    
+    // Get existing profile
+    let mut profile = crate::storage::get_user_profile_safe(&target_user)
+        .ok_or_else(|| "User not found.".to_string())?;
+    
+    // Update only name and email, preserve other fields
+    profile.name = name;
+    profile.email = email;
+    
+    // Save updated profile
+    crate::storage::update_user_profile_safe(&target_user, &profile)?;
+    
+    // Log the update
+    let logger = get_logger("user_management");
+    let severity = get_severity_for_event_type("USER_PROFILE_UPDATE");
+    logger.log(severity, "USER_PROFILE_UPDATE", &format!("User profile updated: {} by {}", target_user, caller), Some(caller.to_string()));
+    
+    Ok(profile)
 }
 
 #[query]

--- a/backend/src/storage/memory.rs
+++ b/backend/src/storage/memory.rs
@@ -97,6 +97,7 @@ impl_storable_with_logging!(
         email: String::new(),
         role: crate::types::UserRole::RegularUser,
         assigned_institution_id: String::new(),
+        assigned_institution_name: String::new(),
         created_at: 0,
         last_login: 0,
     })

--- a/backend/src/storage/memory.rs
+++ b/backend/src/storage/memory.rs
@@ -269,6 +269,22 @@ pub fn update_user_profile_safe(user_identity: &Principal, profile: &UserProfile
     Ok(())
 }
 
+pub fn email_exists(email: &str) -> bool {
+    USER_PROFILES.with(|profiles| {
+        profiles.borrow().iter().any(|(_, profile)| {
+            profile.0.email.to_lowercase() == email.to_lowercase()
+        })
+    })
+}
+
+pub fn email_exists_excluding_user(email: &str, exclude_user: &Principal) -> bool {
+    USER_PROFILES.with(|profiles| {
+        profiles.borrow().iter().any(|(principal, profile)| {
+            principal.0 != *exclude_user && profile.0.email.to_lowercase() == email.to_lowercase()
+        })
+    })
+}
+
 
 
 // Function to get storage statistics for monitoring

--- a/backend/src/types/models.rs
+++ b/backend/src/types/models.rs
@@ -40,7 +40,8 @@ pub struct UserProfile {
     pub name: String,
     pub email: String,
     pub role: UserRole,
-    pub assigned_institution_id: String, // Assigned by admin (empty string if none)
+    pub assigned_institution_id: String,
+    pub assigned_institution_name: String,
     pub created_at: u64,
     pub last_login: u64,
 }

--- a/docs/technical/local_deploy.sh
+++ b/docs/technical/local_deploy.sh
@@ -72,5 +72,5 @@ candid-extractor target/wasm32-unknown-unknown/release/backend.wasm > ./backend/
 echo "Deploying project..."
 dfx deploy --network local --yes
 
-echo "Deployment completed successfully!"
+echo "Local deployment completed successfully!"
 echo "Your application is now running."

--- a/docs/technical/local_deploy_backend.sh
+++ b/docs/technical/local_deploy_backend.sh
@@ -57,5 +57,5 @@ candid-extractor target/wasm32-unknown-unknown/release/backend.wasm > ./backend/
 echo "Deploying backend to local network..."
 dfx deploy backend --network local --yes
 
-echo "Backend deployment completed successfully!"
+echo "Backend local deployment completed successfully!"
 echo "Your backend is now running."

--- a/docs/technical/mainnet_deploy.sh
+++ b/docs/technical/mainnet_deploy.sh
@@ -32,5 +32,5 @@ echo "Set VITE_PRINCIPAL_ID=$VITE_PRINCIPAL_ID"
 echo "Deploying project to mainnet..."
 dfx deploy --network ic --yes
 
-echo "Deployment completed successfully!"
+echo "Mainnet deployment completed successfully!"
 echo "Your application is now running."

--- a/docs/technical/playground_deploy.sh
+++ b/docs/technical/playground_deploy.sh
@@ -32,6 +32,10 @@ dfx identity use default
 
 echo "Starting automated deployment..."
 
+# Change "ic" to "playground" in dfx.json for deployment
+echo "Updating dfx.json to use 'playground' network for internet_identity..."
+sed -i 's/"ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"/"playground": "rdmx6-jaaaa-aaaaa-aaadq-cai"/g' "$PROJECT_ROOT/dfx.json"
+
 # Create canisters if they don't exist
 echo "Creating canisters if needed..."
 dfx canister create --all --network local || echo "Canisters already exist"
@@ -68,10 +72,6 @@ dfx build --network local
 echo "Generating Candid interface..."
 candid-extractor target/wasm32-unknown-unknown/release/backend.wasm > ./backend/backend.did
 
-# Change "ic" to "playground" in dfx.json for deployment
-echo "Updating dfx.json to use 'playground' network for internet_identity..."
-sed -i 's/"ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"/"playground": "rdmx6-jaaaa-aaaaa-aaadq-cai"/g' "$PROJECT_ROOT/dfx.json"
-
 # Deploy the project
 echo "Deploying project..."
 dfx deploy --network playground --yes
@@ -80,5 +80,5 @@ dfx deploy --network playground --yes
 echo "Reverting dfx.json back to 'ic' network..."
 sed -i 's/"playground": "rdmx6-jaaaa-aaaaa-aaadq-cai"/"ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"/g' "$PROJECT_ROOT/dfx.json"
 
-echo "Deployment completed successfully!"
+echo "Playground deployment completed successfully!"
 echo "Your application is now running."


### PR DESCRIPTION
### Changes

✅ Added function to demote superadmins - only other Superadmins can demote, and they cannot demote themselves

✅ Fixed `admin_create_institution_for_user` function to preserve user data (name, email, created_at, and last_login fields are no longer reset)

✅ Superadmins can no longer be assigned to institutions

✅ Added institution name and ID to the response when getting all users

✅ Refactored user registration into 3 separate functions:
  - User registration
  - User login
  - Update user name and email